### PR TITLE
Fix outdated links to my old slides

### DIFF
--- a/2015.md
+++ b/2015.md
@@ -209,7 +209,7 @@
 ## JSib 6 - Sep 19 
 | | | |
 | --- | :---: | --- |
-| [Отзывчивый UI без блокировки Event Loop](https://www.youtube.com/watch?v=Wp0rvEBZU-c)  |  [Денис Речкунов](speakers/Денис%20Речкунов.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/11-ui-event-loop) [:octocat:](https://github.com/pragmader/presentations/tree/master/slides/JSib/2015-09-19_%D0%9E%D1%82%D0%B7%D1%8B%D0%B2%D1%87%D0%B8%D0%B2%D1%8B%D0%B9%20UI%20%D0%B1%D0%B5%D0%B7%20%D0%B1%D0%BB%D0%BE%D0%BA%D0%B8%D1%80%D0%BE%D0%B2%D0%BA%D0%B8%20Event%20Loop/bubble-sort)  |
+| [Отзывчивый UI без блокировки Event Loop](https://www.youtube.com/watch?v=Wp0rvEBZU-c)  |  [Денис Речкунов](speakers/Денис%20Речкунов.md)  | [:notebook:](https://rdner.de/slides/jsib/2015-09-19-blocking-event-loop) [:octocat:](https://rdner.de/slides/jsib/2015-09-19-blocking-event-loop/bubble-sort)  |
 | [Создание двух desktop-приложений на NW.js и Electron](https://www.youtube.com/watch?v=tsjj_I2p5HQ)  |  [Михаил Реенко](speakers/Михаил%20Реенко.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/12-desktop-nodewebkit-electron) [:octocat:](https://github.com/reenko/jsib_6)  |
 ## FrontTalks - Sep 19 
 | | | |
@@ -429,7 +429,7 @@
 ## JSib 4 - Apr 25 
 | | | |
 | --- | :---: | --- |
-| [Многообещающий JavaScript – Promises](https://www.youtube.com/watch?v=LWaXbrLQid0)  |  [Денис Речкунов](speakers/Денис%20Речкунов.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/7-javascript-promises)   |
+| [Многообещающий JavaScript – Promises](https://www.youtube.com/watch?v=LWaXbrLQid0)  |  [Денис Речкунов](speakers/Денис%20Речкунов.md)  | [:notebook:](https://rdner.de/slides/jsib/2015-04-25-promising-javascript)   |
 | [Spy.JS: Новые подходы для отладки Browser-Side и Node.JS приложений](https://www.youtube.com/watch?v=ZRLj5dpute4)  |  [Кирилл Кайсаров](speakers/Кирилл%20Кайсаров.md)  |    |
 ## Secon 2015 - Apr 24 [:movie_camera:](https:&#x2F;&#x2F;www.youtube.com&#x2F;playlist?list&#x3D;PLxwUX4aaSLiJAuWUstGuB8eaCnO-w-7ko)
 | | | |
@@ -489,7 +489,7 @@
 | | | |
 | --- | :---: | --- |
 | [React.js](https://www.youtube.com/watch?v=_IOw9VEGeWA)  |  [Антон Артамонов](speakers/Антон%20Артамонов.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/5-reactjs)   |
-| [Изоморфный фреймворк Catberry.js](https://www.youtube.com/watch?v=TY3JFFp1fJI)  |  [Денис Речкунов](speakers/Денис%20Речкунов.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/6-catberry)   |
+| [Изоморфный фреймворк Catberry.js](https://www.youtube.com/watch?v=TY3JFFp1fJI)  |  [Денис Речкунов](speakers/Денис%20Речкунов.md)  | [:notebook:](https://rdner.de/slides/jsib/2015-03-21-isomorphic-framework-catberry)   |
 ## DUMP2015 - Mar 20 [:movie_camera:](https:&#x2F;&#x2F;www.youtube.com&#x2F;playlist?list&#x3D;PLRdS-n5seLRrvvG0yU3uoYPKQDXvVW2nn)
 | | | |
 | --- | :---: | --- |
@@ -564,4 +564,4 @@
 ## JSib 1 - Jan 17 
 | | | |
 | --- | :---: | --- |
-| [Распространённые ошибки в JavaScript](https://www.youtube.com/watch?v=lJxkPKtl-SQ)  |  [Денис Речкунов](speakers/Денис%20Речкунов.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/java-script-43609932)   |
+| [Распространённые ошибки в JavaScript](https://www.youtube.com/watch?v=lJxkPKtl-SQ)  |  [Денис Речкунов](speakers/Денис%20Речкунов.md)  | [:notebook:](https://rdner.de/slides/jsib/2015-01-17-1-common-mistakes)   |

--- a/events/JSib/2015-01-17 JSib 1.yaml
+++ b/events/JSib/2015-01-17 JSib 1.yaml
@@ -5,4 +5,4 @@ talks:
   - name: Распространённые ошибки в JavaScript
     speaker: Денис Речкунов
     video: https://www.youtube.com/watch?v=lJxkPKtl-SQ
-    presentation: https://www.slideshare.net/JSibNsk/java-script-43609932
+    presentation: https://rdner.de/slides/jsib/2015-01-17-1-common-mistakes

--- a/events/JSib/2015-03-21 JSib 3.yaml
+++ b/events/JSib/2015-03-21 JSib 3.yaml
@@ -11,4 +11,4 @@ talks:
   - name: "Изоморфный фреймворк Catberry.js"
     speaker: Денис Речкунов
     video: https://www.youtube.com/watch?v=TY3JFFp1fJI
-    presentation: https://www.slideshare.net/JSibNsk/6-catberry
+    presentation: https://rdner.de/slides/jsib/2015-03-21-isomorphic-framework-catberry

--- a/events/JSib/2015-04-25 JSib 4.yaml
+++ b/events/JSib/2015-04-25 JSib 4.yaml
@@ -5,7 +5,7 @@ talks:
   - name: "Многообещающий JavaScript – Promises"
     speaker: Денис Речкунов
     video: https://www.youtube.com/watch?v=LWaXbrLQid0
-    presentation: https://www.slideshare.net/JSibNsk/7-javascript-promises
+    presentation: https://rdner.de/slides/jsib/2015-04-25-promising-javascript
   - name: "Spy.JS: Новые подходы для отладки Browser-Side и Node.JS приложений"
     speaker: Кирилл Кайсаров
     video: https://www.youtube.com/watch?v=ZRLj5dpute4

--- a/events/JSib/2015-09-19 JSib 6.yaml
+++ b/events/JSib/2015-09-19 JSib 6.yaml
@@ -5,8 +5,8 @@ talks:
   - name: "Отзывчивый UI без блокировки Event Loop"
     speaker: Денис Речкунов
     video: https://www.youtube.com/watch?v=Wp0rvEBZU-c
-    presentation: https://www.slideshare.net/JSibNsk/11-ui-event-loop
-    code: https://github.com/pragmader/presentations/tree/master/slides/JSib/2015-09-19_%D0%9E%D1%82%D0%B7%D1%8B%D0%B2%D1%87%D0%B8%D0%B2%D1%8B%D0%B9%20UI%20%D0%B1%D0%B5%D0%B7%20%D0%B1%D0%BB%D0%BE%D0%BA%D0%B8%D1%80%D0%BE%D0%B2%D0%BA%D0%B8%20Event%20Loop/bubble-sort
+    presentation: https://rdner.de/slides/jsib/2015-09-19-blocking-event-loop
+    code: https://rdner.de/slides/jsib/2015-09-19-blocking-event-loop/bubble-sort
   - name: "Создание двух desktop-приложений на NW.js и Electron"
     speaker: Михаил Реенко
     video: https://www.youtube.com/watch?v=tsjj_I2p5HQ

--- a/events/JSib/README.md
+++ b/events/JSib/README.md
@@ -11,7 +11,7 @@
 ## JSib 6 - 2015 Sep 19 
 | | | |
 | --- | :---: | --- |
-| [Отзывчивый UI без блокировки Event Loop](https://www.youtube.com/watch?v=Wp0rvEBZU-c)  |  [Денис Речкунов](../../speakers/Денис%20Речкунов.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/11-ui-event-loop) [:octocat:](https://github.com/pragmader/presentations/tree/master/slides/JSib/2015-09-19_%D0%9E%D1%82%D0%B7%D1%8B%D0%B2%D1%87%D0%B8%D0%B2%D1%8B%D0%B9%20UI%20%D0%B1%D0%B5%D0%B7%20%D0%B1%D0%BB%D0%BE%D0%BA%D0%B8%D1%80%D0%BE%D0%B2%D0%BA%D0%B8%20Event%20Loop/bubble-sort)  |
+| [Отзывчивый UI без блокировки Event Loop](https://www.youtube.com/watch?v=Wp0rvEBZU-c)  |  [Денис Речкунов](../../speakers/Денис%20Речкунов.md)  | [:notebook:](https://rdner.de/slides/jsib/2015-09-19-blocking-event-loop) [:octocat:](https://rdner.de/slides/jsib/2015-09-19-blocking-event-loop/bubble-sort)  |
 | [Создание двух desktop-приложений на NW.js и Electron](https://www.youtube.com/watch?v=tsjj_I2p5HQ)  |  [Михаил Реенко](../../speakers/Михаил%20Реенко.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/12-desktop-nodewebkit-electron) [:octocat:](https://github.com/reenko/jsib_6)  |
 ## JSib 5 - 2015 May 31 
 | | | |
@@ -21,13 +21,13 @@
 ## JSib 4 - 2015 Apr 25 
 | | | |
 | --- | :---: | --- |
-| [Многообещающий JavaScript – Promises](https://www.youtube.com/watch?v=LWaXbrLQid0)  |  [Денис Речкунов](../../speakers/Денис%20Речкунов.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/7-javascript-promises)   |
+| [Многообещающий JavaScript – Promises](https://www.youtube.com/watch?v=LWaXbrLQid0)  |  [Денис Речкунов](../../speakers/Денис%20Речкунов.md)  | [:notebook:](https://rdner.de/slides/jsib/2015-04-25-promising-javascript)   |
 | [Spy.JS: Новые подходы для отладки Browser-Side и Node.JS приложений](https://www.youtube.com/watch?v=ZRLj5dpute4)  |  [Кирилл Кайсаров](../../speakers/Кирилл%20Кайсаров.md)  |    |
 ## JSib 3 - 2015 Mar 21 
 | | | |
 | --- | :---: | --- |
 | [React.js](https://www.youtube.com/watch?v=_IOw9VEGeWA)  |  [Антон Артамонов](../../speakers/Антон%20Артамонов.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/5-reactjs)   |
-| [Изоморфный фреймворк Catberry.js](https://www.youtube.com/watch?v=TY3JFFp1fJI)  |  [Денис Речкунов](../../speakers/Денис%20Речкунов.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/6-catberry)   |
+| [Изоморфный фреймворк Catberry.js](https://www.youtube.com/watch?v=TY3JFFp1fJI)  |  [Денис Речкунов](../../speakers/Денис%20Речкунов.md)  | [:notebook:](https://rdner.de/slides/jsib/2015-03-21-isomorphic-framework-catberry)   |
 ## JSib 2 - 2015 Feb 21 
 | | | |
 | --- | :---: | --- |
@@ -36,4 +36,4 @@
 ## JSib 1 - 2015 Jan 17 
 | | | |
 | --- | :---: | --- |
-| [Распространённые ошибки в JavaScript](https://www.youtube.com/watch?v=lJxkPKtl-SQ)  |  [Денис Речкунов](../../speakers/Денис%20Речкунов.md)  | [:notebook:](https://www.slideshare.net/JSibNsk/java-script-43609932)   |
+| [Распространённые ошибки в JavaScript](https://www.youtube.com/watch?v=lJxkPKtl-SQ)  |  [Денис Речкунов](../../speakers/Денис%20Речкунов.md)  | [:notebook:](https://rdner.de/slides/jsib/2015-01-17-1-common-mistakes)   |

--- a/speakers/Денис Речкунов.md
+++ b/speakers/Денис Речкунов.md
@@ -4,10 +4,10 @@
 # Денис Речкунов
 
 ## Отзывчивый UI без блокировки Event Loop
-- 2015 Sep 19 -- [JSib 6](https://www.youtube.com/watch?v=Wp0rvEBZU-c)  | [:notebook:](https://www.slideshare.net/JSibNsk/11-ui-event-loop) | [:octocat:](https://github.com/pragmader/presentations/tree/master/slides/JSib/2015-09-19_%D0%9E%D1%82%D0%B7%D1%8B%D0%B2%D1%87%D0%B8%D0%B2%D1%8B%D0%B9%20UI%20%D0%B1%D0%B5%D0%B7%20%D0%B1%D0%BB%D0%BE%D0%BA%D0%B8%D1%80%D0%BE%D0%B2%D0%BA%D0%B8%20Event%20Loop/bubble-sort) 
+- 2015 Sep 19 -- [JSib 6](https://www.youtube.com/watch?v=Wp0rvEBZU-c)  | [:notebook:](https://rdner.de/slides/jsib/2015-09-19-blocking-event-loop) | [:octocat:](https://rdner.de/slides/jsib/2015-09-19-blocking-event-loop/bubble-sort) 
 ## Многообещающий JavaScript – Promises
-- 2015 Apr 25 -- [JSib 4](https://www.youtube.com/watch?v=LWaXbrLQid0)  | [:notebook:](https://www.slideshare.net/JSibNsk/7-javascript-promises)  
+- 2015 Apr 25 -- [JSib 4](https://www.youtube.com/watch?v=LWaXbrLQid0)  | [:notebook:](https://rdner.de/slides/jsib/2015-04-25-promising-javascript)  
 ## Изоморфный фреймворк Catberry.js
-- 2015 Mar 21 -- [JSib 3](https://www.youtube.com/watch?v=TY3JFFp1fJI)  | [:notebook:](https://www.slideshare.net/JSibNsk/6-catberry)  
+- 2015 Mar 21 -- [JSib 3](https://www.youtube.com/watch?v=TY3JFFp1fJI)  | [:notebook:](https://rdner.de/slides/jsib/2015-03-21-isomorphic-framework-catberry)  
 ## Распространённые ошибки в JavaScript
-- 2015 Jan 17 -- [JSib 1](https://www.youtube.com/watch?v=lJxkPKtl-SQ)  | [:notebook:](https://www.slideshare.net/JSibNsk/java-script-43609932)  
+- 2015 Jan 17 -- [JSib 1](https://www.youtube.com/watch?v=lJxkPKtl-SQ)  | [:notebook:](https://rdner.de/slides/jsib/2015-01-17-1-common-mistakes)  

--- a/speakers/Джеймс Аквух.md
+++ b/speakers/Джеймс Аквух.md
@@ -1,7 +1,7 @@
 ## [Events](../README.md) > [Speakers](../speakers.md)
 ---
 
-# Джеймс Аквух
+# Джеймс Аквух
 
 ## SSR: DIY
-- 2017 May 18 -- [MinskJS 2](https://www.youtube.com/watch?v=H4GTPbf0D40)  | [:notebook:](https://github.com/jakwuh/ssr-demo/tree/master/slides)  
+- 2017 Oct 21 -- [WSD 2017 - Минск](https://www.youtube.com/watch?v=O_IEzdYi634)  | [:notebook:](https://wsd.events/2017/10/21/pres/ssr-diy.pdf)  


### PR DESCRIPTION
Now slide links point to original interactive slides and the broken demo link is fixed.